### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/326/63/85632663.geojson
+++ b/data/856/326/63/85632663.geojson
@@ -920,6 +920,10 @@
     },
     "wof:country":"MH",
     "wof:country_alpha3":"MHL",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"425f6ff092863c8a8d9201f435a9d139",
     "wof:hierarchy":[
         {
@@ -936,7 +940,7 @@
         "eng",
         "mah"
     ],
-    "wof:lastmodified":1566605313,
+    "wof:lastmodified":1582393040,
     "wof:name":"Marshall Islands",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/890/451/463/890451463.geojson
+++ b/data/890/451/463/890451463.geojson
@@ -448,6 +448,10 @@
     },
     "wof:country":"MH",
     "wof:created":1469052780,
+    "wof:geom_alt":[
+        "unknown",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2f4941ab2f55fb4c609d728d89d4f5e9",
     "wof:hierarchy":[
         {
@@ -458,7 +462,7 @@
         }
     ],
     "wof:id":890451463,
-    "wof:lastmodified":1566605322,
+    "wof:lastmodified":1582393040,
     "wof:name":"Majuro",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.