### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/421/203/359/421203359.geojson
+++ b/data/421/203/359/421203359.geojson
@@ -16,6 +16,9 @@
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:cat_x_preferred":[
+        "Atol Lae"
+    ],
     "name:ceb_x_preferred":[
         "Lae"
     ],
@@ -82,6 +85,9 @@
     "name:zho_x_preferred":[
         "\u62c9\u57c3\u74b0\u7901"
     ],
+    "name:zho_x_variant":[
+        "\u840a\u74b0\u7901"
+    ],
     "qs:gn_country":"MH",
     "qs:gn_fcode":"ADM1",
     "qs:gn_id":7303503,
@@ -131,7 +137,7 @@
         "eng",
         "mah"
     ],
-    "wof:lastmodified":1636506371,
+    "wof:lastmodified":1690939428,
     "wof:name":"Lae",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/421/203/361/421203361.geojson
+++ b/data/421/203/361/421203361.geojson
@@ -76,8 +76,14 @@
     "name:swe_x_preferred":[
         "Lib"
     ],
+    "name:urd_x_preferred":[
+        "\u062c\u0632\u06cc\u0631\u06c1 \u0644\u0628"
+    ],
     "name:zho_x_preferred":[
         "\u91cc\u5e03\u5cf6"
+    ],
+    "name:zho_x_variant":[
+        "\u5229\u5e03\u5cf6"
     ],
     "qs:gn_country":"MH",
     "qs:gn_fcode":"ADM1",
@@ -128,7 +134,7 @@
         "eng",
         "mah"
     ],
-    "wof:lastmodified":1566605320,
+    "wof:lastmodified":1690939428,
     "wof:name":"Lib",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/421/204/555/421204555.geojson
+++ b/data/421/204/555/421204555.geojson
@@ -41,6 +41,9 @@
     "name:fra_x_preferred":[
         "Ebeye"
     ],
+    "name:ind_x_preferred":[
+        "Pulau Ebeye"
+    ],
     "name:jpn_x_preferred":[
         "\u30a4\u30fc\u30d0\u30a4\u5cf6"
     ],
@@ -56,11 +59,17 @@
     "name:swe_x_preferred":[
         "Ebeye"
     ],
+    "name:ukr_x_preferred":[
+        "\u0406\u0431\u0430\u0439"
+    ],
     "name:urd_x_preferred":[
         "\u062c\u0632\u06cc\u0631\u06c1 \u0627\u06cc\u0628\u0622\u0626\u06cc"
     ],
     "name:zho_x_preferred":[
         "\u4f0a\u62dc\u5c9b"
+    ],
+    "name:zho_x_variant":[
+        "\u57c3\u8d1d\u8036\u5c9b"
     ],
     "qs:gn_country":"MH",
     "qs:gn_fcode":"PPL",
@@ -102,7 +111,7 @@
         }
     ],
     "wof:id":421204555,
-    "wof:lastmodified":1566605320,
+    "wof:lastmodified":1690939428,
     "wof:name":"Ebeye",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/856/326/63/85632663.geojson
+++ b/data/856/326/63/85632663.geojson
@@ -25,6 +25,9 @@
     "mz:is_current":1,
     "mz:max_zoom":10.0,
     "mz:min_zoom":5.0,
+    "name:abk_x_preferred":[
+        "\u041c\u0430\u0440\u0448\u0430\u043b\u043b\u0442\u04d9\u0438 \u0430\u0434\u0433\u044c\u044b\u043b\u0431\u0436\u044c\u0430\u0445\u0430\u049b\u04d9\u0430"
+    ],
     "name:ace_x_preferred":[
         "Pulo-pulo Marshall"
     ],
@@ -46,6 +49,12 @@
     "name:amh_x_variant":[
         "\u121b\u122d\u123b\u120d \u12a0\u12ed\u120b\u1295\u12f5"
     ],
+    "name:ami_x_preferred":[
+        "Marshall Island"
+    ],
+    "name:anp_x_preferred":[
+        "\u092e\u093e\u0930\u094d\u0936\u0932 \u0926\u094d\u0935\u0940\u092a"
+    ],
     "name:ara_x_preferred":[
         "\u062c\u0632\u0631 \u0645\u0627\u0631\u0634\u0627\u0644"
     ],
@@ -55,6 +64,9 @@
     "name:arg_x_preferred":[
         "Islas Marshall"
     ],
+    "name:ary_x_preferred":[
+        "\u062c\u0632\u0631 \u0645\u0627\u0631\u0634\u0627\u0644"
+    ],
     "name:arz_x_preferred":[
         "\u062c\u0632\u0631 \u0645\u0627\u0631\u0634\u0627\u0644"
     ],
@@ -63,6 +75,9 @@
     ],
     "name:ast_x_variant":[
         "Islles M\u00e1rxal"
+    ],
+    "name:avk_x_preferred":[
+        "Marsalla"
     ],
     "name:azb_x_preferred":[
         "\u0645\u0627\u0631\u0634\u0627\u0644 \u0622\u062f\u0627\u0644\u0627\u0631\u06cc"
@@ -79,6 +94,9 @@
     "name:bam_x_preferred":[
         "Marisali Gun"
     ],
+    "name:ban_x_preferred":[
+        "Kapuloan Marshall"
+    ],
     "name:bcl_x_preferred":[
         "Islas Marshall"
     ],
@@ -93,6 +111,9 @@
     ],
     "name:bho_x_preferred":[
         "\u092e\u093e\u0930\u094d\u0936\u0932 \u0926\u0940\u092a"
+    ],
+    "name:bis_x_preferred":[
+        "Masal Aelan"
     ],
     "name:bod_x_preferred":[
         "\u0f58\u0f62\u0f0b\u0f64\u0f63\u0f0b\u0f42\u0fb3\u0f72\u0f44\u0f0b\u0f55\u0fb2\u0f53\u0f0b\u0f62\u0f92\u0fb1\u0f63\u0f0b\u0f41\u0f56\u0f0d"
@@ -136,11 +157,20 @@
     "name:che_x_variant":[
         "\u041c\u0430\u0440\u0448\u0430\u043b\u043b\u043e\u0432\u0430 \u0433l\u0430\u0439\u0440\u0435\u0448"
     ],
+    "name:chr_x_preferred":[
+        "\u13b9\u13cc\u13b5\u13da\u13a6\u13da\u13db\u13a2"
+    ],
+    "name:chy_x_preferred":[
+        "Marshall Islands"
+    ],
     "name:ckb_x_preferred":[
         "\u062f\u0648\u0648\u0631\u06af\u06d5\u06a9\u0627\u0646\u06cc \u0645\u0627\u0631\u0634\u0627\u06b5"
     ],
     "name:cor_x_preferred":[
         "Ynysow Marshall"
+    ],
+    "name:cos_x_preferred":[
+        "Isuli Marshall"
     ],
     "name:crh_x_preferred":[
         "Mar\u015fall Adalar\u0131"
@@ -150,6 +180,9 @@
     ],
     "name:cze_x_variant":[
         "Marshalovy ostrovy"
+    ],
+    "name:dag_x_preferred":[
+        "Marshall Islands"
     ],
     "name:dan_x_colloquial":[
         "Marshalloerne"
@@ -238,6 +271,9 @@
         "March\u00b7al (payis)",
         "March\u00b7al"
     ],
+    "name:frr_x_preferred":[
+        "Marshall-Eilunen"
+    ],
     "name:fry_x_preferred":[
         "Marshalleilannen"
     ],
@@ -246,6 +282,9 @@
     ],
     "name:gag_x_preferred":[
         "Mar\u015fall Adalar\u0131"
+    ],
+    "name:gcr_x_preferred":[
+        "Zil Marshall"
     ],
     "name:gla_x_preferred":[
         "Na h-Eileanan Mharshall"
@@ -280,8 +319,14 @@
     "name:hat_x_preferred":[
         "Machal"
     ],
+    "name:hat_x_variant":[
+        "Il Machal"
+    ],
     "name:hau_x_preferred":[
         "Tsibiran Marshal"
+    ],
+    "name:hau_x_variant":[
+        "Tsibiran Mashal"
     ],
     "name:hbs_x_preferred":[
         "Mar\u0161alovi Otoci"
@@ -350,6 +395,9 @@
     "name:jpn_x_variant":[
         "\u30de\u30fc\u30b7\u30e3\u30eb\u8af8\u5cf6\u5171\u548c\u56fd"
     ],
+    "name:kaa_x_preferred":[
+        "Marshallov atawlar\u0131"
+    ],
     "name:kan_x_preferred":[
         "\u0cae\u0cbe\u0cb0\u0ccd\u0cb6\u0cb2\u0ccd \u0ca6\u0ccd\u0cb5\u0cc0\u0caa\u0c97\u0cb3\u0cc1"
     ],
@@ -378,6 +426,9 @@
         "\ub9c8\uc0ec\uad70\ub3c4",
         "\ub9c8\uc15c \uc81c\ub3c4 \uacf5\ud654\uad6d",
         "\ub9c8\uc0ec \uad70\ub3c4"
+    ],
+    "name:krj_x_preferred":[
+        "Kamarsiy\u00eblan"
     ],
     "name:kur_x_preferred":[
         "Girav\u00ean Mar\u015fal"
@@ -412,6 +463,12 @@
     "name:lit_x_variant":[
         "Mar\u0161alo salos"
     ],
+    "name:lld_x_preferred":[
+        "Ijules Marshall"
+    ],
+    "name:lmo_x_preferred":[
+        "Isol Marshall"
+    ],
     "name:ltz_x_preferred":[
         "Marshallinselen"
     ],
@@ -428,7 +485,8 @@
         "Maj\u00f5l"
     ],
     "name:mah_x_variant":[
-        "Aolep\u0101n Aor\u014dkin M\u0327aje\u013c"
+        "Aolep\u0101n Aor\u014dkin M\u0327aje\u013c",
+        "M\u0327aje\u013c"
     ],
     "name:mal_x_preferred":[
         "\u0d2e\u0d3e\u0d7c\u0d37\u0d7d \u0d26\u0d4d\u0d35\u0d40\u0d2a\u0d41\u0d15\u0d7e"
@@ -442,6 +500,12 @@
     "name:mar_x_variant":[
         "\u092e\u093e\u0930\u094d\u0936\u0932 \u092c\u0947\u091f\u0947"
     ],
+    "name:mhr_x_preferred":[
+        "\u041c\u0430\u0440\u0448\u0430\u043b\u043b \u041e\u0442\u0440\u043e-\u0432\u043b\u0430\u043a"
+    ],
+    "name:min_x_preferred":[
+        "Kapulauan Marshall"
+    ],
     "name:mkd_x_preferred":[
         "\u041c\u0430\u0440\u0448\u0430\u043b\u0441\u043a\u0438 \u041e\u0441\u0442\u0440\u043e\u0432\u0438"
     ],
@@ -451,14 +515,23 @@
     "name:mlg_x_preferred":[
         "Nosy Marshall"
     ],
+    "name:mlg_x_variant":[
+        "Nosy Marsaly"
+    ],
     "name:mlt_x_preferred":[
         "G\u017cejjer Marshall"
     ],
     "name:mlt_x_variant":[
         "G\u017cejjer ta\u2019 Marshall"
     ],
+    "name:mni_x_preferred":[
+        "\uabc3\uabe5\uabd4\uabc1\uabe6\uabdc \uabcf\uabca\uabe0\uabc1\uabe4\uabe1"
+    ],
     "name:mon_x_preferred":[
         "\u041c\u0430\u0440\u0448\u0430\u043b\u043b\u044b\u043d \u0430\u0440\u043b\u0443\u0443\u0434"
+    ],
+    "name:mri_x_preferred":[
+        "Ng\u0101 Motu M\u0101hara"
     ],
     "name:msa_x_preferred":[
         "Kepulauan Marshall"
@@ -586,6 +659,9 @@
     "name:san_x_variant":[
         "\u092e\u093e\u0930\u094d\u0936\u0932 \u0926\u094d\u0935\u0940\u092a"
     ],
+    "name:sat_x_preferred":[
+        "\u1c62\u1c5f\u1c68\u1c66\u1c5f\u1c5e \u1c6b\u1c64\u1c6f"
+    ],
     "name:scn_x_preferred":[
         "\u00ccsuli Marshall"
     ],
@@ -594,6 +670,9 @@
     ],
     "name:sgs_x_preferred":[
         "Mar\u0161ala Salas"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1019\u1030\u1087\u1075\u102f\u107c\u103a \u1019\u1083\u1038\u101e\u103b\u1084\u1087"
     ],
     "name:sin_x_preferred":[
         "\u0db8\u0dcf\u0dc2\u0dbd\u0dca \u0daf\u0dd6\u0db4\u0dad\u0dca"
@@ -607,14 +686,23 @@
     "name:sme_x_preferred":[
         "Marshallsullot"
     ],
+    "name:smn_x_preferred":[
+        "Marshallsuolluuh"
+    ],
     "name:smo_x_preferred":[
         "Marshall Islands"
+    ],
+    "name:sms_x_preferred":[
+        "Marshall-su\u00f5llu"
     ],
     "name:sna_x_preferred":[
         "Marshall Islands"
     ],
     "name:sna_x_variant":[
         "Zvitsuwa zveMarshall"
+    ],
+    "name:snd_x_preferred":[
+        "\u0645\u0627\u0631\u0634\u0644 \u0622\u0626\u0644\u064a\u0646\u068a\u0632"
     ],
     "name:som_x_preferred":[
         "Jasiirada Marshall"
@@ -630,6 +718,9 @@
     ],
     "name:sqi_x_preferred":[
         "Ishujt Marshall"
+    ],
+    "name:srd_x_preferred":[
+        "\u00ccsulas Marshall"
     ],
     "name:srp_x_preferred":[
         "\u041c\u0430\u0440\u0448\u0430\u043b\u0441\u043a\u0430 \u041e\u0441\u0442\u0440\u0432\u0430"
@@ -669,7 +760,8 @@
         "\u0c2e\u0c3e\u0c30\u0c4d\u0c37\u0c32\u0c4d \u0c26\u0c40\u0c35\u0c41\u0c32\u0c41"
     ],
     "name:tel_x_variant":[
-        "\u0c2e\u0c3e\u0c30\u0c4d\u0c37\u0c32\u0c4d \u0c26\u0c4d\u0c35\u0c40\u0c2a\u0c3e\u0c32\u0c41"
+        "\u0c2e\u0c3e\u0c30\u0c4d\u0c37\u0c32\u0c4d \u0c26\u0c4d\u0c35\u0c40\u0c2a\u0c3e\u0c32\u0c41",
+        "\u0c2e\u0c3e\u0c30\u0c4d\u0c36\u0c32\u0c4d \u0c26\u0c4d\u0c35\u0c40\u0c2a\u0c3e\u0c32\u0c41"
     ],
     "name:tgk_x_preferred":[
         "\u04b6\u0430\u0437\u0438\u0440\u0430\u04b3\u043e\u0438 \u041c\u0430\u0440\u0448\u0430\u043b"
@@ -689,6 +781,9 @@
     "name:ton_x_preferred":[
         "\u02bbOtumotu M\u0101solo"
     ],
+    "name:ton_x_variant":[
+        "\u02bbOtu motu Masolo"
+    ],
     "name:tpi_x_preferred":[
         "Ol Masol Ailan"
     ],
@@ -697,6 +792,9 @@
     ],
     "name:tur_x_preferred":[
         "Marshall Adalar\u0131"
+    ],
+    "name:udm_x_preferred":[
+        "\u041c\u0430\u0440\u0448\u0430\u043b\u043b \u0448\u043e\u0440\u043c\u0443\u04f5\u044a\u0451\u0441"
     ],
     "name:uig_x_preferred":[
         "\u0645\u0627\u0631\u0634\u0627\u0644 \u062a\u0627\u0642\u0649\u0645 \u0626\u0627\u0631\u0627\u0644\u0644\u0649\u0631\u0649"
@@ -723,6 +821,9 @@
     ],
     "name:uzb_x_preferred":[
         "Marshall Orollari"
+    ],
+    "name:vec_x_preferred":[
+        "\u00eczo\u0142e Marshall"
     ],
     "name:vep_x_preferred":[
         "Mar\u0161alan Sared"
@@ -762,6 +863,12 @@
     ],
     "name:yue_x_preferred":[
         "\u99ac\u7d39\u723e\u7fa4\u5cf6"
+    ],
+    "name:yue_x_variant":[
+        "\u99ac\u8607\u7fa4\u5cf6"
+    ],
+    "name:zea_x_preferred":[
+        "Marshalleilan'n"
     ],
     "name:zha_x_preferred":[
         "Marshall Ginzdauj"
@@ -1006,7 +1113,7 @@
         "eng",
         "mah"
     ],
-    "wof:lastmodified":1617827727,
+    "wof:lastmodified":1690939427,
     "wof:name":"Marshall Islands",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/741/43/85674143.geojson
+++ b/data/856/741/43/85674143.geojson
@@ -137,6 +137,9 @@
     "name:spa_x_preferred":[
         "Ratak Chain"
     ],
+    "name:spa_x_variant":[
+        "Cadena Ratak"
+    ],
     "name:swe_x_preferred":[
         "Ratakgruppen"
     ],
@@ -145,6 +148,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0bb0\u0bbe\u0b9f\u0b95\u0bcd \u0b9a\u0bc6\u0baf\u0bbf\u0ba9\u0bcd"
+    ],
+    "name:tam_x_variant":[
+        "\u0bb0\u0bbe\u0b9f\u0b95\u0bcd  \u0b9a\u0bc6\u0baf\u0bbf\u0ba9\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c30\u0c3e\u0c1f\u0c15\u0c4d \u0c1a\u0c48\u0c28\u0c4d"
@@ -160,6 +166,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0631\u0627\u062a\u0627\u06a9 \u0686\u06cc\u0646"
+    ],
+    "name:urd_x_variant":[
+        "\u0633\u0644\u0633\u0644\u06c1 \u0631\u0627\u062a\u06a9"
     ],
     "name:vie_x_preferred":[
         "Chu\u1ed7i \u0111\u1ea3o Ratak"
@@ -270,7 +279,7 @@
         "eng",
         "mah"
     ],
-    "wof:lastmodified":1636506370,
+    "wof:lastmodified":1690939427,
     "wof:name":"Ratak Chain",
     "wof:parent_id":85632663,
     "wof:placetype":"region",

--- a/data/890/412/931/890412931.geojson
+++ b/data/890/412/931/890412931.geojson
@@ -19,6 +19,9 @@
     "mz:is_current":1,
     "mz:is_funky":1,
     "mz:min_zoom":11.0,
+    "name:cat_x_preferred":[
+        "Wotje"
+    ],
     "name:ceb_x_preferred":[
         "Wotje Atoll"
     ],
@@ -79,8 +82,14 @@
     "name:und_x_variant":[
         "Chatham Islands"
     ],
+    "name:urd_x_preferred":[
+        "\u0648\u0627\u062a\u062c\u06d2 \u062c\u0632\u06cc\u0631\u06c1 \u0645\u0631\u062c\u0627\u0646\u06cc"
+    ],
     "name:zho_x_preferred":[
         "\u6c83\u7279\u5091\u74b0\u7901"
+    ],
+    "name:zho_x_variant":[
+        "\u6c83\u5091\u74b0\u7901"
     ],
     "qs:name":"Wotje Atoll",
     "qs:photos_9r":0,
@@ -108,7 +117,7 @@
         }
     ],
     "wof:id":890412931,
-    "wof:lastmodified":1566605320,
+    "wof:lastmodified":1690939428,
     "wof:name":"Wotje Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/933/890412933.geojson
+++ b/data/890/412/933/890412933.geojson
@@ -19,6 +19,9 @@
     "mz:is_current":1,
     "mz:is_funky":1,
     "mz:min_zoom":11.0,
+    "name:cat_x_preferred":[
+        "Wotho"
+    ],
     "name:ceb_x_preferred":[
         "Wotho"
     ],
@@ -76,8 +79,14 @@
     "name:und_x_variant":[
         "Kabahaia Inseln"
     ],
+    "name:urd_x_preferred":[
+        "\u0648\u0648\u062a\u06be\u0648 \u062c\u0632\u06cc\u0631\u06c1 \u0645\u0631\u062c\u0627\u0646\u06cc"
+    ],
     "name:zho_x_preferred":[
         "\u6c83\u7279\u74b0\u7901"
+    ],
+    "name:zho_x_variant":[
+        "\u6c83\u6258\u74b0\u7901"
     ],
     "qs:name":"Wotho Atoll",
     "qs:photos_9r":0,
@@ -105,7 +114,7 @@
         }
     ],
     "wof:id":890412933,
-    "wof:lastmodified":1566605321,
+    "wof:lastmodified":1690939432,
     "wof:name":"Wotho Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/935/890412935.geojson
+++ b/data/890/412/935/890412935.geojson
@@ -94,6 +94,9 @@
     "name:und_x_variant":[
         "Kutusow Atoll"
     ],
+    "name:urd_x_preferred":[
+        "\u0627\u0648\u062a\u06cc\u0631\u06cc\u06a9 \u062c\u0632\u06cc\u0631\u06c1 \u0645\u0631\u062c\u0627\u0646\u06cc"
+    ],
     "name:zho_x_preferred":[
         "\u70cf\u8482\u91cc\u514b\u74b0\u7901"
     ],
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":890412935,
-    "wof:lastmodified":1566605321,
+    "wof:lastmodified":1690939431,
     "wof:name":"Utrik Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/937/890412937.geojson
+++ b/data/890/412/937/890412937.geojson
@@ -22,6 +22,9 @@
     "name:ast_x_preferred":[
         "Atol\u00f3n d'Ujae"
     ],
+    "name:cat_x_preferred":[
+        "Ujae"
+    ],
     "name:ceb_x_preferred":[
         "Ujae Atoll"
     ],
@@ -82,6 +85,9 @@
     "name:und_x_variant":[
         "Katharine Atoll"
     ],
+    "name:urd_x_preferred":[
+        "\u0627\u0648\u062c\u0626\u06d2 \u062c\u0632\u06cc\u0631\u06c1 \u0645\u0631\u062c\u0627\u0646\u06cc"
+    ],
     "name:zho_x_preferred":[
         "\u70cf\u8cc8\u74b0\u7901"
     ],
@@ -112,7 +118,7 @@
         }
     ],
     "wof:id":890412937,
-    "wof:lastmodified":1566605320,
+    "wof:lastmodified":1690939429,
     "wof:name":"Ujae Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/941/890412941.geojson
+++ b/data/890/412/941/890412941.geojson
@@ -31,6 +31,9 @@
     "name:eng_x_preferred":[
         "Rongelap Atoll"
     ],
+    "name:fas_x_preferred":[
+        "\u062c\u0632\u06cc\u0631\u0647 \u0645\u0631\u062c\u0627\u0646\u06cc \u0631\u0627\u0646\u06af\u0644\u067e"
+    ],
     "name:fin_x_preferred":[
         "Rongelap"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:glg_x_preferred":[
         "Atol Rongelap"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05d8\u05d5\u05dc \u05e8\u05d5\u05e0\u05d2\u05dc\u05e4"
     ],
     "name:hrv_x_preferred":[
         "Rongelap"
@@ -94,11 +100,17 @@
     "name:und_x_variant":[
         "Grossrong"
     ],
+    "name:urd_x_preferred":[
+        "\u0631\u0648\u0646\u06af\u06cc\u0644\u0627\u067e \u062c\u0632\u06cc\u0631\u06c1 \u0645\u0631\u062c\u0627\u0646\u06cc"
+    ],
     "name:vie_x_preferred":[
         "Rongelap"
     ],
     "name:zho_x_preferred":[
         "\u6717\u683c\u62c9\u666e\u74b0\u7901"
+    ],
+    "name:zho_x_variant":[
+        "\u6717\u683c\u62c9\u666e\u73af\u7901"
     ],
     "qs:name":"Rongelap Atoll",
     "qs:photos_9r":0,
@@ -126,7 +138,7 @@
         }
     ],
     "wof:id":890412941,
-    "wof:lastmodified":1566605320,
+    "wof:lastmodified":1690939430,
     "wof:name":"Rongelap Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/943/890412943.geojson
+++ b/data/890/412/943/890412943.geojson
@@ -88,8 +88,14 @@
     "name:und_x_variant":[
         "Ross Islands"
     ],
+    "name:urd_x_preferred":[
+        "\u0646\u0627\u0645\u0648 \u062c\u0632\u06cc\u0631\u06c1 \u0645\u0631\u062c\u0627\u0646\u06cc"
+    ],
     "name:zho_x_preferred":[
         "\u7d0d\u6728\u74b0\u7901"
+    ],
+    "name:zho_x_variant":[
+        "\u7d0d\u7a46\u74b0\u7901"
     ],
     "qs:name":"Namu Atoll",
     "qs:photos_9r":0,
@@ -118,7 +124,7 @@
         }
     ],
     "wof:id":890412943,
-    "wof:lastmodified":1566605321,
+    "wof:lastmodified":1690939433,
     "wof:name":"Namu Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/945/890412945.geojson
+++ b/data/890/412/945/890412945.geojson
@@ -19,6 +19,9 @@
     "mz:is_current":1,
     "mz:is_funky":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u062d\u0644\u0642\u0629 \u0646\u0627\u0645\u062f\u0631\u064a\u0643"
+    ],
     "name:ceb_x_preferred":[
         "Namdrik"
     ],
@@ -82,6 +85,9 @@
     "name:und_x_variant":[
         "Klein-Namo"
     ],
+    "name:urd_x_preferred":[
+        "\u0646\u0627\u0645\u062f\u0631\u06cc\u06a9 \u062c\u0632\u06cc\u0631\u06c1 \u0645\u0631\u062c\u0627\u0646\u06cc"
+    ],
     "name:zho_x_preferred":[
         "\u7d0d\u83ab\u91cc\u514b\u74b0\u7901"
     ],
@@ -111,7 +117,7 @@
         }
     ],
     "wof:id":890412945,
-    "wof:lastmodified":1566605321,
+    "wof:lastmodified":1690939433,
     "wof:name":"Namdrik Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/947/890412947.geojson
+++ b/data/890/412/947/890412947.geojson
@@ -25,6 +25,9 @@
     "name:ckb_x_preferred":[
         "\u0645\u06cc\u0644\u06cc-"
     ],
+    "name:dan_x_preferred":[
+        "Mili Atoll"
+    ],
     "name:deu_x_preferred":[
         "Mili"
     ],
@@ -88,6 +91,9 @@
     "name:und_x_variant":[
         "Mire-t\u014d"
     ],
+    "name:urd_x_preferred":[
+        "\u0645\u06cc\u0644\u06cc \u062c\u0632\u06cc\u0631\u06c1 \u0645\u0631\u062c\u0627\u0646\u06cc"
+    ],
     "name:zho_x_preferred":[
         "\u7c73\u5229\u74b0\u7901"
     ],
@@ -118,7 +124,7 @@
         }
     ],
     "wof:id":890412947,
-    "wof:lastmodified":1566605321,
+    "wof:lastmodified":1690939430,
     "wof:name":"Mili Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/949/890412949.geojson
+++ b/data/890/412/949/890412949.geojson
@@ -79,6 +79,9 @@
     "name:und_x_variant":[
         "Mejichi-t\u014d"
     ],
+    "name:urd_x_preferred":[
+        "\u062c\u0632\u06cc\u0631\u06c1 \u0645\u06cc\u062c\u06cc\u062a"
+    ],
     "name:zho_x_preferred":[
         "\u6885\u5409\u7279\u5cf6"
     ],
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":890412949,
-    "wof:lastmodified":1566605321,
+    "wof:lastmodified":1690939431,
     "wof:name":"Mejit Island",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/951/890412951.geojson
+++ b/data/890/412/951/890412951.geojson
@@ -19,6 +19,9 @@
     "mz:is_current":1,
     "mz:is_funky":1,
     "mz:min_zoom":11.0,
+    "name:cat_x_preferred":[
+        "Maloelap"
+    ],
     "name:ceb_x_preferred":[
         "Maloelap Atoll"
     ],
@@ -82,8 +85,14 @@
     "name:tur_x_preferred":[
         "maloelap atoll"
     ],
+    "name:ukr_x_preferred":[
+        "\u041c\u0430\u043b\u043e\u0435\u043b\u0430\u043f"
+    ],
     "name:und_x_variant":[
         "Araktschejeff Islands"
+    ],
+    "name:urd_x_preferred":[
+        "\u0645\u0627\u0644\u0648\u0626\u0644\u0627\u067e \u062c\u0632\u06cc\u0631\u06c1 \u0645\u0631\u062c\u0627\u0646\u06cc"
     ],
     "name:vie_x_preferred":[
         "Maloelap"
@@ -118,7 +127,7 @@
         }
     ],
     "wof:id":890412951,
-    "wof:lastmodified":1566605321,
+    "wof:lastmodified":1690939432,
     "wof:name":"Maloelap Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/955/890412955.geojson
+++ b/data/890/412/955/890412955.geojson
@@ -19,6 +19,15 @@
     "mz:is_current":1,
     "mz:is_funky":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0644\u064a\u0643\u064a\u064a\u0628"
+    ],
+    "name:ary_x_preferred":[
+        "\u0644\u064a\u0643\u064a\u064a\u067e"
+    ],
+    "name:cat_x_preferred":[
+        "Likiep"
+    ],
     "name:ceb_x_preferred":[
         "Likiep Atoll"
     ],
@@ -35,6 +44,9 @@
         "Count Heiden Islands",
         "Legiep Islands",
         "Likiep Atoll"
+    ],
+    "name:fas_x_preferred":[
+        "\u0622\u0628\u200c\u0633\u0646\u06af \u062d\u0644\u0642\u0648\u06cc \u0644\u06cc\u06a9\u06cc\u067e"
     ],
     "name:fin_x_preferred":[
         "Likiep"
@@ -69,6 +81,9 @@
     "name:pol_x_preferred":[
         "Likiep"
     ],
+    "name:por_x_preferred":[
+        "Likiep"
+    ],
     "name:rus_x_preferred":[
         "\u041b\u0438\u043a\u0438\u0435\u043f"
     ],
@@ -81,8 +96,14 @@
     "name:und_x_variant":[
         "Likieb Islands"
     ],
+    "name:urd_x_preferred":[
+        "\u0644\u06cc\u06a9\u0626\u067e \u062c\u0632\u06cc\u0631\u06c1 \u0645\u0631\u062c\u0627\u0646\u06cc"
+    ],
     "name:zho_x_preferred":[
         "\u5229\u57fa\u57c3\u666e\u74b0\u7901"
+    ],
+    "name:zho_x_variant":[
+        "\u5229\u57fa\u666e\u74b0\u7901"
     ],
     "qs:name":"Likiep Atoll",
     "qs:photos_9r":0,
@@ -110,7 +131,7 @@
         }
     ],
     "wof:id":890412955,
-    "wof:lastmodified":1566605320,
+    "wof:lastmodified":1690939429,
     "wof:name":"Likiep Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/959/890412959.geojson
+++ b/data/890/412/959/890412959.geojson
@@ -79,8 +79,14 @@
     "name:und_x_variant":[
         "Elleb"
     ],
+    "name:urd_x_preferred":[
+        "\u062c\u0632\u06cc\u0631\u06c1 \u0644\u0628"
+    ],
     "name:zho_x_preferred":[
         "\u91cc\u5e03\u5cf6"
+    ],
+    "name:zho_x_variant":[
+        "\u5229\u5e03\u5cf6"
     ],
     "qs:name":"Lib Island",
     "qs:photos_9r":0,
@@ -109,7 +115,7 @@
         }
     ],
     "wof:id":890412959,
-    "wof:lastmodified":1566605321,
+    "wof:lastmodified":1690939431,
     "wof:name":"Lib Island",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/961/890412961.geojson
+++ b/data/890/412/961/890412961.geojson
@@ -19,6 +19,9 @@
     "mz:is_current":1,
     "mz:is_funky":1,
     "mz:min_zoom":11.0,
+    "name:cat_x_preferred":[
+        "Atol Lae"
+    ],
     "name:ceb_x_preferred":[
         "Lae"
     ],
@@ -82,8 +85,14 @@
     "name:und_x_variant":[
         "Brown Island"
     ],
+    "name:urd_x_preferred":[
+        "\u0644\u0627\u06d2 \u062c\u0632\u06cc\u0631\u06c1 \u0645\u0631\u062c\u0627\u0646\u06cc"
+    ],
     "name:zho_x_preferred":[
         "\u62c9\u57c3\u74b0\u7901"
+    ],
+    "name:zho_x_variant":[
+        "\u840a\u74b0\u7901"
     ],
     "qs:name":"Lae Atoll",
     "qs:photos_9r":0,
@@ -112,7 +121,7 @@
         }
     ],
     "wof:id":890412961,
-    "wof:lastmodified":1566605321,
+    "wof:lastmodified":1690939431,
     "wof:name":"Lae Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/963/890412963.geojson
+++ b/data/890/412/963/890412963.geojson
@@ -19,6 +19,9 @@
     "mz:is_current":-1,
     "mz:is_funky":1,
     "mz:min_zoom":10.0,
+    "name:ara_x_preferred":[
+        "\u062c\u0632\u064a\u0631\u0629 \u0643\u0648\u0627\u062c\u0627\u0644\u064a\u0646"
+    ],
     "name:ast_x_preferred":[
         "Kwajalein"
     ],
@@ -27,6 +30,9 @@
     ],
     "name:bul_x_preferred":[
         "\u041a\u0443\u0430\u0434\u0436\u0430\u043b\u0438\u043d"
+    ],
+    "name:cat_x_preferred":[
+        "Kwajalein"
     ],
     "name:ceb_x_preferred":[
         "Kwajalein"
@@ -46,6 +52,9 @@
     "name:epo_x_preferred":[
         "Kwajalein"
     ],
+    "name:eus_x_preferred":[
+        "Kwajalein atoloia"
+    ],
     "name:fas_x_preferred":[
         "\u06a9\u0648\u0627\u062c\u0627\u0644\u06cc\u0646"
     ],
@@ -63,6 +72,9 @@
     ],
     "name:hrv_x_preferred":[
         "Kwajalein"
+    ],
+    "name:hun_x_preferred":[
+        "Kwajalein-atoll"
     ],
     "name:ind_x_preferred":[
         "Atol Kwajalein"
@@ -118,11 +130,17 @@
     "name:swe_x_preferred":[
         "Kwajalein"
     ],
+    "name:tur_x_preferred":[
+        "Kwajalein Atol\u00fc"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u0432\u0430\u0434\u0436\u0430\u043b\u0435\u0439\u043d"
     ],
     "name:und_x_variant":[
         "Dove"
+    ],
+    "name:urd_x_preferred":[
+        "\u06a9\u0648\u0627\u062c\u0627\u0644\u0626\u06cc\u0646 \u062c\u0632\u06cc\u0631\u06c1 \u0645\u0631\u062c\u0627\u0646\u06cc"
     ],
     "name:vie_x_preferred":[
         "Kwajalein"
@@ -157,7 +175,7 @@
         }
     ],
     "wof:id":890412963,
-    "wof:lastmodified":1566605320,
+    "wof:lastmodified":1690939429,
     "wof:name":"Kwajalein Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/965/890412965.geojson
+++ b/data/890/412/965/890412965.geojson
@@ -22,6 +22,9 @@
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u041a\u0456\u043b\u0456"
     ],
+    "name:ceb_x_preferred":[
+        "Kili Island"
+    ],
     "name:deu_x_preferred":[
         "Kili-Insel"
     ],
@@ -76,11 +79,20 @@
     "name:spa_x_preferred":[
         "Kili"
     ],
+    "name:swe_x_preferred":[
+        "Kili\u00f6n"
+    ],
     "name:und_x_variant":[
         "Kiri"
     ],
+    "name:urd_x_preferred":[
+        "\u062c\u0632\u06cc\u0631\u06c1 \u06a9\u06cc\u06a9\u06cc"
+    ],
     "name:zho_x_preferred":[
         "\u5409\u5229\u5cf6"
+    ],
+    "name:zho_x_variant":[
+        "\u57fa\u5229\u5cf6"
     ],
     "qs:name":"Kili Island",
     "qs:photos_9r":0,
@@ -108,7 +120,7 @@
         }
     ],
     "wof:id":890412965,
-    "wof:lastmodified":1566605320,
+    "wof:lastmodified":1690939429,
     "wof:name":"Kili Island",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/967/890412967.geojson
+++ b/data/890/412/967/890412967.geojson
@@ -100,6 +100,9 @@
     "name:und_x_variant":[
         "Djaluit"
     ],
+    "name:urd_x_preferred":[
+        "\u062c\u0627\u0644\u0648\u06cc\u062a \u062c\u0632\u06cc\u0631\u06c1 \u0645\u0631\u062c\u0627\u0646\u06cc"
+    ],
     "name:vie_x_preferred":[
         "\u0110\u1ea3o san h\u00f4 v\u00f2ng Jaluit"
     ],
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":890412967,
-    "wof:lastmodified":1566605321,
+    "wof:lastmodified":1690939432,
     "wof:name":"Jaluit Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/969/890412969.geojson
+++ b/data/890/412/969/890412969.geojson
@@ -85,8 +85,14 @@
     "name:und_x_variant":[
         "Bonham Island"
     ],
+    "name:urd_x_preferred":[
+        "\u062c\u0632\u06cc\u0631\u06c1 \u062c\u0627\u0628\u0627\u062a"
+    ],
     "name:zho_x_preferred":[
         "\u8cc8\u666e\u5766\u5cf6"
+    ],
+    "name:zho_x_variant":[
+        "\u8cc8\u5e03\u6c83\u7279\u5cf6"
     ],
     "qs:name":"Jabat Island",
     "qs:photos_9r":0,
@@ -115,7 +121,7 @@
         }
     ],
     "wof:id":890412969,
-    "wof:lastmodified":1566605321,
+    "wof:lastmodified":1690939432,
     "wof:name":"Jabat Island",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/971/890412971.geojson
+++ b/data/890/412/971/890412971.geojson
@@ -19,6 +19,9 @@
     "mz:is_current":1,
     "mz:is_funky":1,
     "mz:min_zoom":11.0,
+    "name:ara_x_preferred":[
+        "\u0622\u062a\u0648\u0644 \u0625\u0646\u064a\u0648\u064a\u062a\u0648\u0643"
+    ],
     "name:ast_x_preferred":[
         "Atol\u00f3n d'Enewetak"
     ],
@@ -41,6 +44,9 @@
         "Eniwetok"
     ],
     "name:est_x_preferred":[
+        "Enewetak"
+    ],
+    "name:eus_x_preferred":[
         "Enewetak"
     ],
     "name:fas_x_preferred":[
@@ -115,6 +121,9 @@
     "name:und_x_variant":[
         "Brown Island"
     ],
+    "name:urd_x_preferred":[
+        "\u0627\u06cc\u0646\u06cc\u0648\u06cc\u0679\u06a9 \u062c\u0632\u06cc\u0631\u06c1 \u0645\u0631\u062c\u0627\u0646\u06cc"
+    ],
     "name:vie_x_preferred":[
         "\u0110\u1ea3o san h\u00f4 v\u00f2ng Enewetak"
     ],
@@ -148,7 +157,7 @@
         }
     ],
     "wof:id":890412971,
-    "wof:lastmodified":1566605321,
+    "wof:lastmodified":1690939430,
     "wof:name":"Enewetak Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/973/890412973.geojson
+++ b/data/890/412/973/890412973.geojson
@@ -88,6 +88,9 @@
     "name:und_x_variant":[
         "Watts Inseln"
     ],
+    "name:urd_x_preferred":[
+        "\u0622\u0626\u0644\u0648\u06a9 \u062c\u0632\u06cc\u0631\u06c1 \u0645\u0631\u062c\u0627\u0646\u06cc"
+    ],
     "name:vie_x_preferred":[
         "\u0110\u1ea3o san h\u00f4 v\u00f2ng Ailuk"
     ],
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":890412973,
-    "wof:lastmodified":1566605321,
+    "wof:lastmodified":1690939433,
     "wof:name":"Ailuk Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/412/977/890412977.geojson
+++ b/data/890/412/977/890412977.geojson
@@ -43,6 +43,9 @@
     "name:eng_x_preferred":[
         "Ailinglaplap Atoll"
     ],
+    "name:fas_x_preferred":[
+        "\u0622\u062a\u0644 \u0622\u06cc\u0644\u06cc\u0646\u06af\u0644\u0627\u067e\u0644\u0627\u067e"
+    ],
     "name:fin_x_preferred":[
         "Ailinglaplap"
     ],
@@ -106,6 +109,9 @@
     "name:zho_x_preferred":[
         "\u57c3\u6797\u62c9\u666e\u62c9\u666e\u74b0\u7901"
     ],
+    "name:zho_x_variant":[
+        "\u827e\u6797\u62c9\u5e15\u62c9\u666e\u73af\u7901"
+    ],
     "qs:name":"Ailinglaplap Atoll",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -133,7 +139,7 @@
         }
     ],
     "wof:id":890412977,
-    "wof:lastmodified":1566605320,
+    "wof:lastmodified":1690939430,
     "wof:name":"Ailinglaplap Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/428/733/890428733.geojson
+++ b/data/890/428/733/890428733.geojson
@@ -97,8 +97,14 @@
     "name:und_x_variant":[
         "Fourteen Islands"
     ],
+    "name:urd_x_preferred":[
+        "\u0627\u06cc\u0628\u0648\u0646 \u062c\u0632\u06cc\u0631\u06c1 \u0645\u0631\u062c\u0627\u0646\u06cc"
+    ],
     "name:zho_x_preferred":[
         "\u57c3\u5d29\u74b0\u7901"
+    ],
+    "name:zho_x_variant":[
+        "\u57c3\u90a6\u74b0\u7901"
     ],
     "qs:name":"Ebon Atoll",
     "qs:photos_9r":0,
@@ -126,7 +132,7 @@
         }
     ],
     "wof:id":890428733,
-    "wof:lastmodified":1566605322,
+    "wof:lastmodified":1690939434,
     "wof:name":"Ebon Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/428/735/890428735.geojson
+++ b/data/890/428/735/890428735.geojson
@@ -64,8 +64,14 @@
     "name:deu_x_preferred":[
         "Bikini-Atoll"
     ],
+    "name:ell_x_preferred":[
+        "\u0391\u03c4\u03cc\u03bb\u03b7 \u039c\u03c0\u03b9\u03ba\u03af\u03bd\u03b9"
+    ],
     "name:eng_x_preferred":[
         "Bikini Atoll"
+    ],
+    "name:epo_x_preferred":[
+        "Bikini Atolo"
     ],
     "name:est_x_preferred":[
         "Bikini"
@@ -103,6 +109,9 @@
     "name:hun_x_variant":[
         "Bikini-atoll"
     ],
+    "name:ido_x_preferred":[
+        "Atolo Bikini"
+    ],
     "name:ind_x_preferred":[
         "Atol Bikini"
     ],
@@ -133,8 +142,14 @@
     "name:ltz_x_preferred":[
         "Bikini-Atoll"
     ],
+    "name:mar_x_preferred":[
+        "\u092c\u093f\u0915\u093f\u0928\u0940 \u090f\u091f\u094b\u0932"
+    ],
     "name:mkd_x_preferred":[
         "\u0411\u0438\u043a\u0438\u043d\u0438"
+    ],
+    "name:msa_x_preferred":[
+        "Atol Bikini"
     ],
     "name:nep_x_preferred":[
         "\u092c\u093f\u0915\u093f\u0928\u0940 \u090f\u091f\u094b\u0932"
@@ -172,8 +187,14 @@
     "name:slk_x_preferred":[
         "Atol Bikini"
     ],
+    "name:slv_x_preferred":[
+        "atol Bikini"
+    ],
     "name:spa_x_preferred":[
         "Atol\u00f3n Bikini"
+    ],
+    "name:srp_x_preferred":[
+        "\u0411\u0438\u043a\u0438\u043d\u0438 \u0430\u0442\u043e\u043b"
     ],
     "name:swa_x_preferred":[
         "Bikini"
@@ -198,6 +219,12 @@
     ],
     "name:vie_x_preferred":[
         "\u0110\u1ea3o san h\u00f4 v\u00f2ng Bikini"
+    ],
+    "name:war_x_preferred":[
+        "Atol Bikini"
+    ],
+    "name:yue_x_preferred":[
+        "\u6bd4\u5805\u5c3c\u74b0\u7901"
     ],
     "name:zho_x_preferred":[
         "\u6bd4\u57fa\u5c3c\u5c9b"
@@ -232,7 +259,7 @@
         }
     ],
     "wof:id":890428735,
-    "wof:lastmodified":1566605322,
+    "wof:lastmodified":1690939434,
     "wof:name":"Bikini Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/428/737/890428737.geojson
+++ b/data/890/428/737/890428737.geojson
@@ -22,6 +22,9 @@
     "name:ast_x_preferred":[
         "Atol\u00f3n d'Aur"
     ],
+    "name:cat_x_preferred":[
+        "Aur"
+    ],
     "name:ceb_x_preferred":[
         "Aur Atoll"
     ],
@@ -85,6 +88,9 @@
     "name:und_x_variant":[
         "Traversey Islands"
     ],
+    "name:urd_x_preferred":[
+        "\u0622\u0648\u0631 \u062c\u0632\u06cc\u0631\u06c1 \u0645\u0631\u062c\u0627\u0646\u06cc"
+    ],
     "name:zho_x_preferred":[
         "\u5967\u723e\u74b0\u7901"
     ],
@@ -115,7 +121,7 @@
         }
     ],
     "wof:id":890428737,
-    "wof:lastmodified":1566605321,
+    "wof:lastmodified":1690939433,
     "wof:name":"Aur Atoll",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/451/463/890451463.geojson
+++ b/data/890/451/463/890451463.geojson
@@ -30,6 +30,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u062c\u0648\u0631\u0648"
     ],
+    "name:ary_x_preferred":[
+        "\u0645\u0627\u062c\u0648\u0631\u0648"
+    ],
     "name:ast_x_preferred":[
         "Mayuru"
     ],
@@ -39,8 +42,14 @@
     "name:bak_x_preferred":[
         "\u041c\u0430\u0434\u0436\u0443\u0440\u043e"
     ],
+    "name:ban_x_preferred":[
+        "Majuro"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041c\u0430\u0434\u0436\u0443\u0440\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041c\u0430\u0434\u0436\u0443\u0440\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u099c\u09c1\u09b0\u09cb"
@@ -114,6 +123,9 @@
     "name:gla_x_preferred":[
         "Majuro"
     ],
+    "name:gle_x_preferred":[
+        "Majuro"
+    ],
     "name:glg_x_preferred":[
         "Majuro"
     ],
@@ -171,6 +183,9 @@
     "name:kat_x_preferred":[
         "\u10db\u10d0\u10ef\u10e3\u10e0\u10dd"
     ],
+    "name:kaz_x_preferred":[
+        "\u041c\u0430\u0434\u0436\u0443\u0440\u043e"
+    ],
     "name:kin_x_preferred":[
         "Majuro"
     ],
@@ -186,11 +201,17 @@
     "name:lav_x_preferred":[
         "Mad\u017euro"
     ],
+    "name:lij_x_preferred":[
+        "Majuro"
+    ],
     "name:lit_x_preferred":[
         "Mad\u017e\u016bras"
     ],
     "name:ltz_x_preferred":[
         "Majuro"
+    ],
+    "name:mal_x_preferred":[
+        "\u0d2e\u0d3e\u0d1c\u0d41\u0d31\u0d4b"
     ],
     "name:mar_x_preferred":[
         "\u092e\u093e\u091c\u0941\u0930\u094b"
@@ -237,6 +258,9 @@
     "name:por_x_preferred":[
         "Majuro"
     ],
+    "name:pus_x_preferred":[
+        "\u0645\u0627\u062c\u0648\u0631\u0648"
+    ],
     "name:ron_x_preferred":[
         "Majuro"
     ],
@@ -248,6 +272,9 @@
     ],
     "name:sah_x_preferred":[
         "\u041c\u0430\u0434\u044c\u0443\u0440\u043e"
+    ],
+    "name:sat_x_preferred":[
+        "\u1c62\u1c5f\u1c61\u1c69\u1c68\u1c5a"
     ],
     "name:sco_x_preferred":[
         "Majuro"
@@ -268,6 +295,9 @@
         "Majuro"
     ],
     "name:sqi_x_preferred":[
+        "Majuro"
+    ],
+    "name:srd_x_preferred":[
         "Majuro"
     ],
     "name:srp_x_preferred":[
@@ -296,6 +326,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c2e\u0c3e\u0c1c\u0c41\u0c30\u0c4b"
+    ],
+    "name:tgk_x_preferred":[
+        "\u041c\u0430\u04b7\u0443\u0440\u043e"
     ],
     "name:tgl_x_preferred":[
         "Majuro"
@@ -326,6 +359,12 @@
     ],
     "name:war_x_preferred":[
         "Majuro"
+    ],
+    "name:wuu_x_preferred":[
+        "\u9a6c\u6731\u7f57"
+    ],
+    "name:xmf_x_preferred":[
+        "\u10db\u10d0\u10ef\u10e3\u10e0\u10dd"
     ],
     "name:yue_x_preferred":[
         "\u99ac\u7956\u76e7"
@@ -476,7 +515,7 @@
         }
     ],
     "wof:id":890451463,
-    "wof:lastmodified":1636506371,
+    "wof:lastmodified":1690939434,
     "wof:name":"Majuro",
     "wof:parent_id":-1,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.