### PR TITLE
mh concordances, placetype local, and more

### DIFF
--- a/data/421/203/355/421203355.geojson
+++ b/data/421/203/355/421203355.geojson
@@ -18,7 +18,7 @@
     ],
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
@@ -55,8 +55,10 @@
     "wof:concordances":{
         "gn:id":7303495,
         "gp:id":24549836,
+        "iso:code":"MH-AUR",
         "qs_pg:id":59683
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MH",
     "wof:created":1459010148,
     "wof:geomhash":"33f502ed8032703c3cdd1fb492060d6a",
@@ -75,7 +77,7 @@
         "eng",
         "mah"
     ],
-    "wof:lastmodified":1694493127,
+    "wof:lastmodified":1695884284,
     "wof:name":"Aur",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/421/203/359/421203359.geojson
+++ b/data/421/203/359/421203359.geojson
@@ -18,7 +18,7 @@
     ],
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
@@ -121,10 +121,12 @@
     "wof:concordances":{
         "gn:id":7303503,
         "gp:id":24549847,
+        "iso:code":"MH-LAE",
         "qs_pg:id":59684,
         "wd:id":"Q741121",
         "wk:page":"Lae Atoll"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MH",
     "wof:created":1459010148,
     "wof:geomhash":"3a3b973e76a36d261e6c4b77621edd30",
@@ -143,7 +145,7 @@
         "eng",
         "mah"
     ],
-    "wof:lastmodified":1694493128,
+    "wof:lastmodified":1695884289,
     "wof:name":"Lae",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/421/203/361/421203361.geojson
+++ b/data/421/203/361/421203361.geojson
@@ -142,7 +142,7 @@
         "eng",
         "mah"
     ],
-    "wof:lastmodified":1695880873,
+    "wof:lastmodified":1695884280,
     "wof:name":"Lib",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/421/203/361/421203361.geojson
+++ b/data/421/203/361/421203361.geojson
@@ -18,7 +18,7 @@
     ],
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
@@ -118,10 +118,12 @@
     "wof:concordances":{
         "gn:id":7303522,
         "gp:id":24549848,
+        "iso:code":"MH-LIB",
         "qs_pg:id":59685,
         "wd:id":"Q376862",
         "wk:page":"Lib Island"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MH",
     "wof:created":1459010148,
     "wof:geomhash":"1da88b5797bfb873c5fdffc1f88c2e4a",
@@ -140,7 +142,7 @@
         "eng",
         "mah"
     ],
-    "wof:lastmodified":1694493125,
+    "wof:lastmodified":1695880873,
     "wof:name":"Lib",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/326/63/85632663.geojson
+++ b/data/856/326/63/85632663.geojson
@@ -1081,6 +1081,7 @@
         "hasc:id":"MH",
         "icao:code":"V7",
         "ioc:id":"MSH",
+        "iso:code":"MH",
         "iso:id":"MH-MH",
         "itu:id":"MHL",
         "m49:code":"584",
@@ -1094,6 +1095,7 @@
         "wk:page":"Marshall Islands",
         "wmo:id":"MH"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MH",
     "wof:country_alpha3":"MHL",
     "wof:geom_alt":[
@@ -1116,7 +1118,7 @@
         "eng",
         "mah"
     ],
-    "wof:lastmodified":1694639573,
+    "wof:lastmodified":1695881233,
     "wof:name":"Marshall Islands",
     "wof:parent_id":102191583,
     "wof:placetype":"country",

--- a/data/856/741/39/85674139.geojson
+++ b/data/856/741/39/85674139.geojson
@@ -23,7 +23,7 @@
     "mps:latitude":5.92127,
     "mps:longitude":169.653836,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:eng_x_preferred":[
@@ -168,8 +168,10 @@
         "fips:code":"",
         "gn:id":-1,
         "gp:id":-99,
-        "hasc:id":"MH."
+        "hasc:id":"MH.",
+        "iso:code":"MH-L"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MH",
     "wof:geomhash":"63f7e8574b58b332957b3e7364776a1a",
     "wof:hierarchy":[
@@ -188,7 +190,7 @@
         "eng",
         "mah"
     ],
-    "wof:lastmodified":1694493128,
+    "wof:lastmodified":1695884289,
     "wof:name":"Railik Chain",
     "wof:parent_id":85632663,
     "wof:placetype":"region",

--- a/data/856/741/43/85674143.geojson
+++ b/data/856/741/43/85674143.geojson
@@ -23,7 +23,7 @@
     "mps:latitude":7.082567,
     "mps:longitude":171.193611,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -264,9 +264,11 @@
         "gn:id":-1,
         "gp:id":-99,
         "hasc:id":"MH.",
+        "iso:code":"MH-T",
         "unlc:id":"MH-T",
         "wd:id":"Q700048"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MH",
     "wof:geomhash":"6bf220e77054068261d77ad09420eaba",
     "wof:hierarchy":[
@@ -285,7 +287,7 @@
         "eng",
         "mah"
     ],
-    "wof:lastmodified":1694493128,
+    "wof:lastmodified":1695884289,
     "wof:name":"Ratak Chain",
     "wof:parent_id":85632663,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.